### PR TITLE
refactor: Transport trait 方法改为接受 &GraphRequest

### DIFF
--- a/crates/nodeimg-app/src/execution.rs
+++ b/crates/nodeimg-app/src/execution.rs
@@ -72,7 +72,7 @@ impl ExecutionManager {
 
         let repaint = self.repaint.clone();
         std::thread::spawn(move || {
-            let result = transport.execute(request, tagged_tx.into_sender());
+            let result = transport.execute(&request, tagged_tx.into_sender());
             if let Err(e) = result {
                 eprintln!("[execution] Task error for trigger {}: {}", trigger_node, e);
             }

--- a/crates/nodeimg-app/src/node/viewer.rs
+++ b/crates/nodeimg-app/src/node/viewer.rs
@@ -324,7 +324,7 @@ impl SnarlViewer<NodeInstance> for NodeViewer {
                 // Step 2: Evaluate local nodes only (skips AI nodes, never blocks).
                 let request = self.build_graph_request(node_id, snarl);
 
-                if let Err(e) = self.transport.evaluate_local_sync(request.clone()) {
+                if let Err(e) = self.transport.evaluate_local_sync(&request) {
                     self.backend_status = Some(e);
                 } else {
                     self.backend_status = None;
@@ -333,7 +333,7 @@ impl SnarlViewer<NodeInstance> for NodeViewer {
                 // Step 3: Check for pending AI work.
                 if !self.execution_manager.is_running(node_id.0) {
                     if let Some((ai_node_id, _graph_json)) =
-                        self.transport.pending_ai_execution(request.clone())
+                        self.transport.pending_ai_execution(&request)
                     {
                         eprintln!(
                             "[backend] Spawning async AI execution: trigger={} ai_node={}",

--- a/crates/nodeimg-engine/src/transport/local.rs
+++ b/crates/nodeimg-engine/src/transport/local.rs
@@ -204,11 +204,11 @@ impl LocalTransport {
 impl ProcessingTransport for LocalTransport {
     fn execute(
         &self,
-        request: GraphRequest,
+        request: &GraphRequest,
         progress: Sender<ExecuteProgress>,
     ) -> Result<(), String> {
         // Phase 1: Preparation — build internal types from request, then topo-sort
-        let (nodes, connections) = self.prepare_from_request(&request);
+        let (nodes, connections) = self.prepare_from_request(request);
         let order = EvalEngine::topo_sort(request.target_node, &connections)?;
 
         // Phase 2: Set up cache downstream relationships
@@ -398,9 +398,9 @@ impl ProcessingTransport for LocalTransport {
         Ok(defs)
     }
 
-    fn evaluate_local_sync(&self, request: GraphRequest) -> Result<(), String> {
+    fn evaluate_local_sync(&self, request: &GraphRequest) -> Result<(), String> {
         // Phase 1: Preparation — build internal types from request
-        let (nodes, connections) = self.prepare_from_request(&request);
+        let (nodes, connections) = self.prepare_from_request(request);
 
         // Phase 2: Evaluate (backend=None skips AI nodes)
         let registry = self.registry.lock().unwrap();
@@ -426,10 +426,10 @@ impl ProcessingTransport for LocalTransport {
 
     fn pending_ai_execution(
         &self,
-        request: GraphRequest,
+        request: &GraphRequest,
     ) -> Option<(NodeId, serde_json::Value)> {
         // Build internal types from GraphRequest
-        let (nodes, connections) = self.prepare_from_request(&request);
+        let (nodes, connections) = self.prepare_from_request(request);
 
         let registry = self.registry.lock().unwrap();
         let cache = self.cache.lock().unwrap();
@@ -582,7 +582,7 @@ mod tests {
             target_node: 0,
         };
 
-        transport.execute(request, tx).unwrap();
+        transport.execute(&request, tx).unwrap();
 
         let mut got_completed = false;
         let mut got_finished = false;
@@ -638,7 +638,7 @@ mod tests {
             target_node: 1,
         };
 
-        transport.execute(request, tx).unwrap();
+        transport.execute(&request, tx).unwrap();
 
         let mut completed_nodes = Vec::new();
         let mut got_finished = false;
@@ -680,13 +680,13 @@ mod tests {
         };
 
         let (tx, _) = mpsc::channel();
-        transport.execute(request.clone(), tx).unwrap();
+        transport.execute(&request, tx).unwrap();
 
         // Invalidate and re-execute — should succeed without error
         transport.invalidate(0);
 
         let (tx2, rx2) = mpsc::channel();
-        transport.execute(request, tx2).unwrap();
+        transport.execute(&request, tx2).unwrap();
 
         let mut got_completed = false;
         while let Ok(progress) = rx2.try_recv() {
@@ -720,12 +720,12 @@ mod tests {
         };
 
         let (tx, _) = mpsc::channel();
-        transport.execute(request.clone(), tx).unwrap();
+        transport.execute(&request, tx).unwrap();
 
         transport.invalidate_all();
 
         let (tx2, rx2) = mpsc::channel();
-        transport.execute(request, tx2).unwrap();
+        transport.execute(&request, tx2).unwrap();
 
         let mut got_completed = false;
         while let Ok(progress) = rx2.try_recv() {
@@ -803,7 +803,7 @@ mod tests {
             target_node: 0,
         };
 
-        let result = transport.execute(request, tx);
+        let result = transport.execute(&request, tx);
         assert!(result.is_err());
         let err_msg = result.unwrap_err();
         assert!(
@@ -855,7 +855,7 @@ mod tests {
             target_node: 1,
         };
 
-        transport.evaluate_local_sync(request).unwrap();
+        transport.evaluate_local_sync(&request).unwrap();
 
         let cached = transport.get_cached(1);
         assert!(cached.is_some(), "node 1 should be cached after evaluate_local_sync");

--- a/crates/nodeimg-engine/src/transport/mod.rs
+++ b/crates/nodeimg-engine/src/transport/mod.rs
@@ -16,7 +16,7 @@ pub trait ProcessingTransport: Send + Sync + 'static {
     /// Execute a node graph, pushing per-node results via `progress`.
     fn execute(
         &self,
-        request: GraphRequest,
+        request: &GraphRequest,
         progress: Sender<ExecuteProgress>,
     ) -> Result<(), String>;
 
@@ -36,7 +36,7 @@ pub trait ProcessingTransport: Send + Sync + 'static {
     fn node_types(&self) -> Result<Vec<NodeTypeDef>, String>;
 
     /// Synchronous local evaluation (skips AI nodes). Results written to internal cache.
-    fn evaluate_local_sync(&self, request: GraphRequest) -> Result<(), String>;
+    fn evaluate_local_sync(&self, request: &GraphRequest) -> Result<(), String>;
 
     /// Query cached output for a node (does not trigger execution).
     fn get_cached(&self, node_id: NodeId) -> Option<HashMap<String, Value>>;
@@ -45,7 +45,7 @@ pub trait ProcessingTransport: Send + Sync + 'static {
     /// Returns (ai_node_id, serialized_subgraph_json) if found.
     fn pending_ai_execution(
         &self,
-        request: GraphRequest,
+        request: &GraphRequest,
     ) -> Option<(NodeId, serde_json::Value)>;
 
     /// Check if adding connections would create a cycle.


### PR DESCRIPTION
## Summary
- `ProcessingTransport` trait 的 `execute`、`evaluate_local_sync`、`pending_ai_execution` 三个方法签名从 owned `GraphRequest` 改为 `&GraphRequest`
- 同步更新 `LocalTransport` 实现、app 调用方、execution manager 调用点
- 消除 `show_body` 中对 `request.clone()` 的两次调用

Closes #70

## Test plan
- [x] `cargo test --workspace` 全部 117 个测试通过
- [ ] `cargo run -p nodeimg-app --release` 运行正常

🤖 Generated with [Claude Code](https://claude.com/claude-code)