### PR TITLE
docs: 补充工作流程教训——禁止 main 直接 commit，用 rebase 同步

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,6 +44,8 @@ python/                  — AI 后端（FastAPI + SDXL）
 - PR 描述中用 `Closes #N` / `Fixes #N` 关联 Issue
 - 新功能/架构变更需要先走 brainstorming 设计流程，再写实现计划，再开发
 - Code Review 分级：简单 PR 快速扫描，复杂 PR 使用 superpowers:requesting-code-review
+- 所有 commit 必须在功能分支上，绝不在 main 上直接 commit
+- 用 `git pull --rebase` 同步 main，避免产生 merge commit
 
 ## 开发约定
 

--- a/docs/开发工作流程.md
+++ b/docs/开发工作流程.md
@@ -99,7 +99,7 @@ gh pr merge                                        # 合并 PR
 git worktree remove .claude/worktrees/xxx          # 先删 worktree
 git branch -d feature/xxx                           # 再删本地分支
 git checkout main                                   # 切回主分支
-git pull                                            # 同步 main
+git pull --rebase                                   # 同步 main（rebase 避免 merge commit）
 ```
 
 > 必须先删 worktree 再删分支，worktree 存在时无法删除分支。
@@ -109,6 +109,8 @@ git pull                                            # 同步 main
 ## 关键原则
 
 - **每个功能/修复 = 一个独立分支 + 一个 PR**，互不干扰
+- **所有 commit 必须在功能分支上**，绝不在 main 上直接 commit（包括设计文档等辅助文件）
 - **main 始终是经过审查的干净代码**
+- **用 `git pull --rebase` 同步 main**，避免产生多余的 merge commit
 - **长期分支定期 rebase main**，避免冲突积累
 - **多任务并行用 worktree**，同一分支不能被两个 worktree 同时检出，完成后及时清理


### PR DESCRIPTION
## Summary
- 关键原则新增：所有 commit 必须在功能分支上，禁止 main 直接 commit
- Step 6 的 `git pull` 改为 `git pull --rebase`，避免产生 merge commit
- CLAUDE.md 同步更新

🤖 Generated with [Claude Code](https://claude.com/claude-code)