### PR TITLE
refactor: 将序列化职责封装进 Transport trait #73

### DIFF
--- a/crates/nodeimg-app/src/app.rs
+++ b/crates/nodeimg-app/src/app.rs
@@ -1,5 +1,6 @@
 use eframe::egui;
 use egui_snarl::Snarl;
+use std::collections::HashMap;
 use std::collections::VecDeque;
 use std::path::PathBuf;
 use std::process::{Child, Command};
@@ -10,6 +11,7 @@ use crate::gpu::gpu_context_from_eframe;
 use crate::node::serial::Serializer;
 use crate::node::viewer::NodeViewer;
 use nodeimg_engine::transport::BackendClient;
+use nodeimg_engine::transport::NodeTypeDef;
 use nodeimg_types::node_instance::NodeInstance;
 use nodeimg_engine::transport::local::LocalTransport;
 use nodeimg_engine::transport::ProcessingTransport;
@@ -121,7 +123,7 @@ impl App {
         // Don't set viewer.backend — backend is inside transport now
 
         // Auto-load: try to restore from autosave file
-        let snarl = Self::try_auto_load(&transport);
+        let snarl = Self::try_auto_load(&transport, &viewer.node_type_defs);
 
         Self {
             snarl,
@@ -258,18 +260,13 @@ impl App {
     }
 
     /// Try to load the autosave file on startup.
-    fn try_auto_load(transport: &LocalTransport) -> Snarl<NodeInstance> {
+    fn try_auto_load(transport: &LocalTransport, type_defs: &HashMap<String, NodeTypeDef>) -> Snarl<NodeInstance> {
         let path = Self::autosave_path();
         if path.exists() {
             if let Ok(json) = std::fs::read_to_string(&path) {
-                let result = transport.with_registry(|registry| {
-                    Serializer::load(&json, registry)
-                });
-                match result {
+                match transport.load_graph(&json) {
                     Ok(graph) => {
-                        let snarl = transport.with_registry(|registry| {
-                            Serializer::restore(&graph, registry)
-                        });
+                        let snarl = Serializer::restore(&graph, type_defs);
                         eprintln!("[project] Restored autosave ({} nodes)", graph.nodes.len());
                         return snarl;
                     }
@@ -288,9 +285,7 @@ impl App {
             return;
         }
 
-        let graph = self.viewer.transport.with_registry(|reg| {
-            Serializer::snapshot(&self.snarl, reg)
-        });
+        let graph = Serializer::snapshot(&self.snarl, &self.viewer.node_type_defs);
         let json = match Serializer::save(&graph) {
             Ok(j) => j,
             Err(e) => {
@@ -322,9 +317,7 @@ impl App {
 
     /// Save As: pick a file and write the graph.
     fn save_as(&mut self) {
-        let graph = self.viewer.transport.with_registry(|reg| {
-            Serializer::snapshot(&self.snarl, reg)
-        });
+        let graph = Serializer::snapshot(&self.snarl, &self.viewer.node_type_defs);
         let json = match Serializer::save(&graph) {
             Ok(j) => j,
             Err(e) => {
@@ -357,14 +350,10 @@ impl App {
         {
             match std::fs::read_to_string(&path) {
                 Ok(json) => {
-                    let load_result = self.viewer.transport.with_registry(|reg| {
-                        Serializer::load(&json, reg)
-                    });
+                    let load_result = self.viewer.transport.load_graph(&json);
                     match load_result {
                         Ok(graph) => {
-                            self.snarl = self.viewer.transport.with_registry(|reg| {
-                                Serializer::restore(&graph, reg)
-                            });
+                            self.snarl = Serializer::restore(&graph, &self.viewer.node_type_defs);
                             self.viewer.invalidate_all();
                             self.current_file = Some(path.clone());
                             self.last_saved_json = Some(json);
@@ -384,9 +373,7 @@ impl App {
 
     /// Quick save: write to current_file or autosave path.
     fn quick_save(&mut self) {
-        let graph = self.viewer.transport.with_registry(|reg| {
-            Serializer::snapshot(&self.snarl, reg)
-        });
+        let graph = Serializer::snapshot(&self.snarl, &self.viewer.node_type_defs);
         let json = match Serializer::save(&graph) {
             Ok(j) => j,
             Err(e) => {

--- a/crates/nodeimg-app/src/app.rs
+++ b/crates/nodeimg-app/src/app.rs
@@ -111,7 +111,12 @@ impl App {
                 Ok(count) => eprintln!("[backend] Registered {} AI node types", count),
                 Err(e) => eprintln!("[backend] Failed to register AI nodes: {}", e),
             }
-            viewer.node_type_defs = transport.node_types().unwrap_or_default();
+            viewer.node_type_defs = transport
+                .node_types()
+                .unwrap_or_default()
+                .into_iter()
+                .map(|d| (d.type_id.clone(), d))
+                .collect();
         }
         // Don't set viewer.backend — backend is inside transport now
 

--- a/crates/nodeimg-app/src/node/serial.rs
+++ b/crates/nodeimg-app/src/node/serial.rs
@@ -1,9 +1,8 @@
-use nodeimg_engine::NodeRegistry;
+use nodeimg_engine::transport::NodeTypeDef;
 use nodeimg_types::node_instance::NodeInstance;
+use nodeimg_types::serial_data::*;
 use egui_snarl::{InPinId, NodeId, OutPinId, Snarl};
 use std::collections::HashMap;
-
-pub use nodeimg_types::serial_data::*;
 
 pub struct Serializer;
 
@@ -12,31 +11,10 @@ impl Serializer {
         serde_json::to_string_pretty(graph)
     }
 
-    pub fn load(json: &str, registry: &NodeRegistry) -> Result<SerializedGraph, String> {
-        let mut graph: SerializedGraph =
-            serde_json::from_str(json).map_err(|e| format!("JSON parse error: {}", e))?;
-
-        for node in &mut graph.nodes {
-            if let Some(def) = registry.get(&node.type_id) {
-                for param in &def.params {
-                    if !node.params.contains_key(&param.name) {
-                        if let Some(sv) = SerializedValue::from_value(&param.default) {
-                            node.params.insert(param.name.clone(), sv);
-                        }
-                    }
-                }
-            }
-            // Unknown node types are intentionally kept in the graph
-            // so they survive save/load. EvalEngine skips them.
-        }
-
-        Ok(graph)
-    }
-
     /// Take a snapshot of the current Snarl graph into a SerializedGraph.
     pub fn snapshot(
         snarl: &Snarl<NodeInstance>,
-        registry: &NodeRegistry,
+        type_defs: &HashMap<String, NodeTypeDef>,
     ) -> SerializedGraph {
         let mut nodes = Vec::new();
         for (node_id, pos, instance) in snarl.nodes_pos_ids() {
@@ -58,13 +36,13 @@ impl Serializer {
         for (out_pin, in_pin) in snarl.wires() {
             let from_name = snarl
                 .get_node(out_pin.node)
-                .and_then(|inst| registry.get(&inst.type_id))
+                .and_then(|inst| type_defs.get(&inst.type_id))
                 .and_then(|def| def.outputs.get(out_pin.output))
                 .map(|p| p.name.clone())
                 .unwrap_or_default();
             let to_name = snarl
                 .get_node(in_pin.node)
-                .and_then(|inst| registry.get(&inst.type_id))
+                .and_then(|inst| type_defs.get(&inst.type_id))
                 .and_then(|def| def.inputs.get(in_pin.input))
                 .map(|p| p.name.clone())
                 .unwrap_or_default();
@@ -86,25 +64,30 @@ impl Serializer {
     /// Restore a SerializedGraph into a fresh Snarl, returning it.
     pub fn restore(
         graph: &SerializedGraph,
-        registry: &NodeRegistry,
+        type_defs: &HashMap<String, NodeTypeDef>,
     ) -> Snarl<NodeInstance> {
         let mut snarl = Snarl::new();
-        // Map old serialized IDs -> new Snarl NodeIds
         let mut id_map: HashMap<usize, NodeId> = HashMap::new();
 
         for sn in &graph.nodes {
-            let instance = match registry.instantiate(&sn.type_id) {
-                Some(mut inst) => {
-                    // Apply saved param values
+            let instance = match type_defs.get(&sn.type_id) {
+                Some(def) => {
+                    let mut params: HashMap<String, nodeimg_types::value::Value> = def
+                        .params
+                        .iter()
+                        .map(|p| (p.name.clone(), p.default.to_value()))
+                        .collect();
                     for (k, sv) in &sn.params {
-                        inst.params.insert(k.clone(), sv.to_value());
+                        params.insert(k.clone(), sv.to_value());
                     }
-                    inst
+                    NodeInstance {
+                        type_id: sn.type_id.clone(),
+                        params,
+                    }
                 }
                 None => {
-                    // Unknown node type -- create a placeholder instance so the
-                    // graph structure is preserved across save/load even when
-                    // the backend is not connected.
+                    // Unknown node type — create placeholder so the graph
+                    // structure is preserved across save/load.
                     let mut params = HashMap::new();
                     for (k, sv) in &sn.params {
                         params.insert(k.clone(), sv.to_value());
@@ -130,14 +113,13 @@ impl Serializer {
                 None => continue,
             };
 
-            // Resolve pin names -> indices
             let out_idx = snarl
                 .get_node(from_id)
-                .and_then(|inst| registry.get(&inst.type_id))
+                .and_then(|inst| type_defs.get(&inst.type_id))
                 .and_then(|def| def.outputs.iter().position(|p| p.name == sc.from_pin));
             let in_idx = snarl
                 .get_node(to_id)
-                .and_then(|inst| registry.get(&inst.type_id))
+                .and_then(|inst| type_defs.get(&inst.type_id))
                 .and_then(|def| def.inputs.iter().position(|p| p.name == sc.to_pin));
 
             if let (Some(out_idx), Some(in_idx)) = (out_idx, in_idx) {

--- a/crates/nodeimg-app/src/node/viewer.rs
+++ b/crates/nodeimg-app/src/node/viewer.rs
@@ -24,7 +24,7 @@ use std::sync::Arc;
 pub struct NodeViewer {
     // Transport abstraction (new)
     pub transport: Arc<LocalTransport>,
-    pub node_type_defs: Vec<NodeTypeDef>,
+    pub node_type_defs: HashMap<String, NodeTypeDef>,
     pub execution_manager: ExecutionManager,
 
     pub widget_registry: WidgetRegistry,
@@ -46,7 +46,12 @@ pub struct NodeViewer {
 
 impl NodeViewer {
     pub fn new(theme: Arc<dyn Theme>, gpu_ctx: Option<Arc<GpuContext>>, transport: Arc<LocalTransport>) -> Self {
-        let node_type_defs = transport.node_types().unwrap_or_default();
+        let node_type_defs: HashMap<String, NodeTypeDef> = transport
+            .node_types()
+            .unwrap_or_default()
+            .into_iter()
+            .map(|d| (d.type_id.clone(), d))
+            .collect();
         let execution_manager = ExecutionManager::new(Arc::clone(&transport) as Arc<dyn ProcessingTransport>);
 
         Self {
@@ -66,7 +71,7 @@ impl NodeViewer {
 
     /// Find a NodeTypeDef by type_id from the cached list.
     fn find_type_def(&self, type_id: &str) -> Option<&NodeTypeDef> {
-        self.node_type_defs.iter().find(|d| d.type_id == type_id)
+        self.node_type_defs.get(type_id)
     }
 
     pub fn invalidate(&mut self, node_id: NodeId) {

--- a/crates/nodeimg-engine/src/transport/local.rs
+++ b/crates/nodeimg-engine/src/transport/local.rs
@@ -13,6 +13,7 @@ use nodeimg_gpu::GpuContext;
 use nodeimg_types::category::CategoryRegistry;
 use nodeimg_types::constraint::Constraint;
 use nodeimg_types::data_type::{DataTypeId, DataTypeRegistry};
+use nodeimg_types::serial_data::{SerializedGraph, SerializedValue};
 use nodeimg_types::value::Value;
 use std::collections::{HashMap, HashSet};
 use std::sync::mpsc::Sender;
@@ -460,6 +461,26 @@ impl ProcessingTransport for LocalTransport {
             .collect();
 
         EvalEngine::topo_sort(target, &connections).is_err()
+    }
+
+    fn load_graph(&self, json: &str) -> Result<SerializedGraph, String> {
+        let mut graph: SerializedGraph =
+            serde_json::from_str(json).map_err(|e| format!("JSON parse error: {}", e))?;
+
+        let registry = self.registry.lock().unwrap();
+        for node in &mut graph.nodes {
+            if let Some(def) = registry.get(&node.type_id) {
+                for param in &def.params {
+                    if !node.params.contains_key(&param.name) {
+                        if let Some(sv) = SerializedValue::from_value(&param.default) {
+                            node.params.insert(param.name.clone(), sv);
+                        }
+                    }
+                }
+            }
+        }
+
+        Ok(graph)
     }
 }
 
@@ -911,5 +932,56 @@ mod tests {
             },
         ];
         assert!(transport.would_create_cycle(0, &connections));
+    }
+
+    #[test]
+    fn test_load_graph_fills_defaults() {
+        let transport = create_test_transport();
+        register_test_source(&transport);
+
+        // JSON with test_source node but missing "value" param
+        let json = r#"{
+            "version": 1,
+            "nodes": [{
+                "id": 0,
+                "type_id": "test_source",
+                "position": [0.0, 0.0],
+                "params": {}
+            }],
+            "connections": []
+        }"#;
+
+        let graph = transport.load_graph(json).unwrap();
+        assert_eq!(graph.nodes.len(), 1);
+        // "value" param should be filled with default (Float 0.0)
+        assert!(graph.nodes[0].params.contains_key("value"));
+    }
+
+    #[test]
+    fn test_load_graph_preserves_unknown_nodes() {
+        let transport = create_test_transport();
+
+        let json = r#"{
+            "version": 1,
+            "nodes": [{
+                "id": 0,
+                "type_id": "nonexistent_node",
+                "position": [100.0, 200.0],
+                "params": {"foo": {"type": "Float", "value": 1.0}}
+            }],
+            "connections": []
+        }"#;
+
+        let graph = transport.load_graph(json).unwrap();
+        assert_eq!(graph.nodes.len(), 1);
+        assert_eq!(graph.nodes[0].type_id, "nonexistent_node");
+        assert!(graph.nodes[0].params.contains_key("foo"));
+    }
+
+    #[test]
+    fn test_load_graph_invalid_json() {
+        let transport = create_test_transport();
+        let result = transport.load_graph("not json");
+        assert!(result.is_err());
     }
 }

--- a/crates/nodeimg-engine/src/transport/mod.rs
+++ b/crates/nodeimg-engine/src/transport/mod.rs
@@ -3,6 +3,7 @@ pub mod local;
 pub use crate::internal::backend::BackendClient;
 
 use crate::cache::NodeId;
+use nodeimg_types::serial_data::SerializedGraph;
 use nodeimg_types::value::Value;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
@@ -54,6 +55,9 @@ pub trait ProcessingTransport: Send + Sync + 'static {
         target: NodeId,
         connections: &[ConnectionRequest],
     ) -> bool;
+
+    /// Parse project file JSON and fill missing params with defaults.
+    fn load_graph(&self, json: &str) -> Result<SerializedGraph, String>;
 }
 
 // === Execution Progress ===

--- a/docs/superpowers/plans/2026-03-26-transport-serialization.md
+++ b/docs/superpowers/plans/2026-03-26-transport-serialization.md
@@ -1,0 +1,470 @@
+# Transport 序列化重构实现计划
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 移除 app 对 NodeRegistry 的依赖，将序列化职责封装进 Transport trait。
+
+**Architecture:** Transport trait 新增 `load_graph` 方法处理 JSON 解析+默认值填充。App 的 Serializer 改用已有的 `NodeTypeDef`（通过 `node_types()` 获取）代替 NodeRegistry。NodeViewer 中已有的 `node_type_defs` 缓存从 `Vec` 改为 `HashMap` 以支持高效查找。
+
+**Tech Stack:** Rust, nodeimg workspace (types/engine/app crates)
+
+**Spec:** `docs/superpowers/specs/2026-03-26-transport-serialization-design.md`
+
+---
+
+### Task 1: Transport trait 新增 `load_graph` 方法
+
+**Files:**
+- Modify: `crates/nodeimg-engine/src/transport/mod.rs:15-57` (ProcessingTransport trait)
+- Modify: `crates/nodeimg-engine/src/transport/local.rs:205-463` (ProcessingTransport impl)
+
+- [ ] **Step 1: 在 trait 中添加 `load_graph` 方法签名**
+
+在 `crates/nodeimg-engine/src/transport/mod.rs` 顶部添加 import：
+
+```rust
+use nodeimg_types::serial_data::SerializedGraph;
+```
+
+在 `ProcessingTransport` trait 的 `would_create_cycle` 方法之后添加：
+
+```rust
+    /// Parse project file JSON and fill missing params with defaults.
+    fn load_graph(&self, json: &str) -> Result<SerializedGraph, String>;
+```
+
+- [ ] **Step 2: 在 LocalTransport 中实现 `load_graph`**
+
+在 `crates/nodeimg-engine/src/transport/local.rs` 的 `impl ProcessingTransport for LocalTransport` 块末尾（`would_create_cycle` 之后）添加：
+
+```rust
+    fn load_graph(&self, json: &str) -> Result<SerializedGraph, String> {
+        let mut graph: SerializedGraph =
+            serde_json::from_str(json).map_err(|e| format!("JSON parse error: {}", e))?;
+
+        let registry = self.registry.lock().unwrap();
+        for node in &mut graph.nodes {
+            if let Some(def) = registry.get(&node.type_id) {
+                for param in &def.params {
+                    if !node.params.contains_key(&param.name) {
+                        if let Some(sv) = SerializedValue::from_value(&param.default) {
+                            node.params.insert(param.name.clone(), sv);
+                        }
+                    }
+                }
+            }
+        }
+
+        Ok(graph)
+    }
+```
+
+在 `local.rs` 顶部添加 import：
+
+```rust
+use nodeimg_types::serial_data::{SerializedGraph, SerializedValue};
+```
+
+- [ ] **Step 3: 确认编译通过**
+
+Run: `cargo build --workspace 2>&1 | tail -5`
+Expected: 编译成功
+
+- [ ] **Step 4: 为 `load_graph` 添加测试**
+
+在 `local.rs` 的 `#[cfg(test)] mod tests` 块末尾添加：
+
+```rust
+    #[test]
+    fn test_load_graph_fills_defaults() {
+        let transport = create_test_transport();
+        register_test_source(&transport);
+
+        // JSON with test_source node but missing "value" param
+        let json = r#"{
+            "version": 1,
+            "nodes": [{
+                "id": 0,
+                "type_id": "test_source",
+                "position": [0.0, 0.0],
+                "params": {}
+            }],
+            "connections": []
+        }"#;
+
+        let graph = transport.load_graph(json).unwrap();
+        assert_eq!(graph.nodes.len(), 1);
+        // "value" param should be filled with default (Float 0.0)
+        assert!(graph.nodes[0].params.contains_key("value"));
+    }
+
+    #[test]
+    fn test_load_graph_preserves_unknown_nodes() {
+        let transport = create_test_transport();
+
+        let json = r#"{
+            "version": 1,
+            "nodes": [{
+                "id": 0,
+                "type_id": "nonexistent_node",
+                "position": [100.0, 200.0],
+                "params": {"foo": {"type": "Float", "value": 1.0}}
+            }],
+            "connections": []
+        }"#;
+
+        let graph = transport.load_graph(json).unwrap();
+        assert_eq!(graph.nodes.len(), 1);
+        assert_eq!(graph.nodes[0].type_id, "nonexistent_node");
+        assert!(graph.nodes[0].params.contains_key("foo"));
+    }
+
+    #[test]
+    fn test_load_graph_invalid_json() {
+        let transport = create_test_transport();
+        let result = transport.load_graph("not json");
+        assert!(result.is_err());
+    }
+```
+
+- [ ] **Step 5: 运行测试**
+
+Run: `cargo test -p nodeimg-engine -- test_load_graph 2>&1 | tail -10`
+Expected: 3 个测试通过
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add crates/nodeimg-engine/src/transport/mod.rs crates/nodeimg-engine/src/transport/local.rs
+git commit -m "feat: Transport trait 新增 load_graph 方法 #73"
+```
+
+---
+
+### Task 2: NodeViewer 的 `node_type_defs` 改为 HashMap
+
+**Files:**
+- Modify: `crates/nodeimg-app/src/node/viewer.rs:27` (字段类型)
+- Modify: `crates/nodeimg-app/src/node/viewer.rs:49,54` (初始化)
+- Modify: `crates/nodeimg-app/src/node/viewer.rs:68-70` (find_type_def)
+- Modify: `crates/nodeimg-app/src/app.rs:114` (刷新缓存)
+
+- [ ] **Step 1: 修改字段类型和初始化**
+
+在 `viewer.rs` 中将字段声明改为：
+
+```rust
+    pub node_type_defs: HashMap<String, NodeTypeDef>,
+```
+
+修改 `NodeViewer::new()` 中的初始化：
+
+```rust
+        let node_type_defs: HashMap<String, NodeTypeDef> = transport
+            .node_types()
+            .unwrap_or_default()
+            .into_iter()
+            .map(|d| (d.type_id.clone(), d))
+            .collect();
+```
+
+修改 `find_type_def`：
+
+```rust
+    fn find_type_def(&self, type_id: &str) -> Option<&NodeTypeDef> {
+        self.node_type_defs.get(type_id)
+    }
+```
+
+- [ ] **Step 2: 修改 app.rs 中的缓存刷新**
+
+在 `app.rs:114` 将：
+
+```rust
+            viewer.node_type_defs = transport.node_types().unwrap_or_default();
+```
+
+改为：
+
+```rust
+            viewer.node_type_defs = transport
+                .node_types()
+                .unwrap_or_default()
+                .into_iter()
+                .map(|d| (d.type_id.clone(), d))
+                .collect();
+```
+
+- [ ] **Step 3: 确认编译通过**
+
+Run: `cargo build --workspace 2>&1 | tail -5`
+Expected: 编译成功
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add crates/nodeimg-app/src/node/viewer.rs crates/nodeimg-app/src/app.rs
+git commit -m "refactor: NodeViewer.node_type_defs 改为 HashMap 以支持高效查找 #73"
+```
+
+---
+
+### Task 3: Serializer 改用 NodeTypeDef + app.rs 移除 with_registry
+
+> serial.rs 和 app.rs 必须同时改，否则中间状态编译不过（签名不匹配）。
+
+**Files:**
+- Modify: `crates/nodeimg-app/src/node/serial.rs` (改造 Serializer)
+- Modify: `crates/nodeimg-app/src/app.rs` (7 处 with_registry 调用)
+
+- [ ] **Step 1: 改造 serial.rs — 修改 import**
+
+替换 `serial.rs` 的 import：
+
+```rust
+use nodeimg_engine::transport::{NodeTypeDef, ParamValue};
+use nodeimg_types::node_instance::NodeInstance;
+use nodeimg_types::serial_data::*;
+use egui_snarl::{InPinId, NodeId, OutPinId, Snarl};
+use std::collections::HashMap;
+```
+
+注意：移除 `use nodeimg_engine::NodeRegistry;`，新增 `use nodeimg_engine::transport::{NodeTypeDef, ParamValue};`。
+
+- [ ] **Step 2: 改造 serial.rs — 移除 `load` 方法**
+
+删除 `Serializer::load()` 方法（第 15-34 行）。这个逻辑已经在 Task 1 中移到了 `Transport::load_graph()`。
+
+- [ ] **Step 3: 改造 serial.rs — `snapshot` 方法**
+
+将 `snapshot` 的签名从 `registry: &NodeRegistry` 改为 `type_defs: &HashMap<String, NodeTypeDef>`：
+
+```rust
+    pub fn snapshot(
+        snarl: &Snarl<NodeInstance>,
+        type_defs: &HashMap<String, NodeTypeDef>,
+    ) -> SerializedGraph {
+        let mut nodes = Vec::new();
+        for (node_id, pos, instance) in snarl.nodes_pos_ids() {
+            let mut params = HashMap::new();
+            for (k, v) in &instance.params {
+                if let Some(sv) = SerializedValue::from_value(v) {
+                    params.insert(k.clone(), sv);
+                }
+            }
+            nodes.push(SerializedNode {
+                id: node_id.0,
+                type_id: instance.type_id.clone(),
+                position: [pos.x, pos.y],
+                params,
+            });
+        }
+
+        let mut connections = Vec::new();
+        for (out_pin, in_pin) in snarl.wires() {
+            let from_name = snarl
+                .get_node(out_pin.node)
+                .and_then(|inst| type_defs.get(&inst.type_id))
+                .and_then(|def| def.outputs.get(out_pin.output))
+                .map(|p| p.name.clone())
+                .unwrap_or_default();
+            let to_name = snarl
+                .get_node(in_pin.node)
+                .and_then(|inst| type_defs.get(&inst.type_id))
+                .and_then(|def| def.inputs.get(in_pin.input))
+                .map(|p| p.name.clone())
+                .unwrap_or_default();
+            connections.push(SerializedConnection {
+                from_node: out_pin.node.0,
+                from_pin: from_name,
+                to_node: in_pin.node.0,
+                to_pin: to_name,
+            });
+        }
+
+        SerializedGraph {
+            version: FORMAT_VERSION,
+            nodes,
+            connections,
+        }
+    }
+```
+
+- [ ] **Step 4: 改造 serial.rs — `restore` 方法**
+
+将 `restore` 的签名从 `registry: &NodeRegistry` 改为 `type_defs: &HashMap<String, NodeTypeDef>`。保留未知节点的 placeholder 路径：
+
+```rust
+    pub fn restore(
+        graph: &SerializedGraph,
+        type_defs: &HashMap<String, NodeTypeDef>,
+    ) -> Snarl<NodeInstance> {
+        let mut snarl = Snarl::new();
+        let mut id_map: HashMap<usize, NodeId> = HashMap::new();
+
+        for sn in &graph.nodes {
+            let instance = match type_defs.get(&sn.type_id) {
+                Some(def) => {
+                    // Start with defaults from NodeTypeDef
+                    let mut params: HashMap<String, nodeimg_types::value::Value> = def
+                        .params
+                        .iter()
+                        .map(|p| (p.name.clone(), p.default.to_value()))
+                        .collect();
+                    // Override with saved values
+                    for (k, sv) in &sn.params {
+                        params.insert(k.clone(), sv.to_value());
+                    }
+                    NodeInstance {
+                        type_id: sn.type_id.clone(),
+                        params,
+                    }
+                }
+                None => {
+                    // Unknown node type — create placeholder
+                    let mut params = HashMap::new();
+                    for (k, sv) in &sn.params {
+                        params.insert(k.clone(), sv.to_value());
+                    }
+                    NodeInstance {
+                        type_id: sn.type_id.clone(),
+                        params,
+                    }
+                }
+            };
+            let pos = eframe::egui::pos2(sn.position[0], sn.position[1]);
+            let new_id = snarl.insert_node(pos, instance);
+            id_map.insert(sn.id, new_id);
+        }
+
+        for sc in &graph.connections {
+            let from_id = match id_map.get(&sc.from_node) {
+                Some(&id) => id,
+                None => continue,
+            };
+            let to_id = match id_map.get(&sc.to_node) {
+                Some(&id) => id,
+                None => continue,
+            };
+
+            let out_idx = snarl
+                .get_node(from_id)
+                .and_then(|inst| type_defs.get(&inst.type_id))
+                .and_then(|def| def.outputs.iter().position(|p| p.name == sc.from_pin));
+            let in_idx = snarl
+                .get_node(to_id)
+                .and_then(|inst| type_defs.get(&inst.type_id))
+                .and_then(|def| def.inputs.iter().position(|p| p.name == sc.to_pin));
+
+            if let (Some(out_idx), Some(in_idx)) = (out_idx, in_idx) {
+                snarl.connect(
+                    OutPinId {
+                        node: from_id,
+                        output: out_idx,
+                    },
+                    InPinId {
+                        node: to_id,
+                        input: in_idx,
+                    },
+                );
+            }
+        }
+
+        snarl
+    }
+```
+
+- [ ] **Step 5: 改造 app.rs — 添加 import**
+
+在 `app.rs` 顶部添加：
+
+```rust
+use std::collections::HashMap;
+use nodeimg_engine::transport::NodeTypeDef;
+```
+
+- [ ] **Step 6: 改造 app.rs — `try_auto_load`**
+
+将 `try_auto_load` 改为：
+
+```rust
+    fn try_auto_load(transport: &LocalTransport, type_defs: &HashMap<String, NodeTypeDef>) -> Snarl<NodeInstance> {
+        let path = Self::autosave_path();
+        if path.exists() {
+            if let Ok(json) = std::fs::read_to_string(&path) {
+                match transport.load_graph(&json) {
+                    Ok(graph) => {
+                        let snarl = Serializer::restore(&graph, type_defs);
+                        eprintln!("[project] Restored autosave ({} nodes)", graph.nodes.len());
+                        return snarl;
+                    }
+                    Err(e) => {
+                        eprintln!("[project] Failed to load autosave: {}", e);
+                    }
+                }
+            }
+        }
+        Snarl::new()
+    }
+```
+
+同时更新调用处，从 `Self::try_auto_load(&transport)` 改为 `Self::try_auto_load(&transport, &viewer.node_type_defs)`。
+
+- [ ] **Step 7: 改造 app.rs — `auto_save`、`save_as`、`quick_save`**
+
+三个方法中的 `with_registry` 调用统一改为：
+
+```rust
+        let graph = Serializer::snapshot(&self.snarl, &self.viewer.node_type_defs);
+```
+
+- [ ] **Step 8: 改造 app.rs — `open_file`**
+
+将 `open_file` 中的两处 `with_registry` 调用改为：
+
+```rust
+                    let load_result = self.viewer.transport.load_graph(&json);
+                    match load_result {
+                        Ok(graph) => {
+                            self.snarl = Serializer::restore(&graph, &self.viewer.node_type_defs);
+```
+
+- [ ] **Step 9: 确认编译通过**
+
+Run: `cargo build --workspace 2>&1 | tail -5`
+Expected: 编译成功
+
+- [ ] **Step 10: 验证依赖已移除**
+
+Run: `grep -r "with_registry" crates/nodeimg-app/`
+Expected: 无输出
+
+Run: `grep -r "NodeRegistry" crates/nodeimg-app/`
+Expected: 无输出
+
+- [ ] **Step 11: Commit**
+
+```bash
+git add crates/nodeimg-app/src/node/serial.rs crates/nodeimg-app/src/app.rs
+git commit -m "refactor: Serializer 改用 NodeTypeDef，app 移除所有 with_registry 调用 #73"
+```
+
+---
+
+### Task 4: 运行完整测试 + 验证
+
+**Files:** 无新改动
+
+- [ ] **Step 1: 运行全量测试**
+
+Run: `cargo test --workspace 2>&1 | tail -20`
+Expected: 所有测试通过
+
+- [ ] **Step 2: 编译 release**
+
+Run: `cargo build -p nodeimg-app --release 2>&1 | tail -5`
+Expected: 编译成功
+
+- [ ] **Step 3: Commit（如有修复）**
+
+如果前面有测试失败并修复，在此提交修复。

--- a/docs/superpowers/specs/2026-03-26-transport-serialization-design.md
+++ b/docs/superpowers/specs/2026-03-26-transport-serialization-design.md
@@ -1,0 +1,90 @@
+# 设计：将序列化职责封装进 Transport trait
+
+> Issue: #73
+> 日期: 2026-03-26
+
+## 问题
+
+App 的 Serializer 直接使用 `NodeRegistry`（engine 内部类型）做项目文件的保存/加载。导致：
+
+1. `with_registry()` 是 `LocalTransport` 的具体方法，不在 `ProcessingTransport` trait 上，远程 transport 无法实现
+2. App 依赖了 engine 的内部类型，破坏了 Transport 抽象层的隔离
+3. 无头运行（nodeimg-server）无法复用序列化逻辑
+
+## 当前状态
+
+Serializer 用 `NodeRegistry` 做三件事：
+
+| 方法 | 用途 | 需要 registry 做什么 |
+|------|------|---------------------|
+| `load(json, registry)` | JSON → SerializedGraph | 填充缺失参数的默认值 |
+| `snapshot(snarl, registry)` | Snarl → SerializedGraph | pin 索引 → 名称转换 |
+| `restore(graph, registry)` | SerializedGraph → Snarl | pin 名称 → 索引转换 + 节点实例化 |
+| `save(graph)` | SerializedGraph → JSON | 不需要 registry |
+
+App 中有 7 处 `with_registry()` 调用，全部是为了包装 Serializer 调用。
+
+## 方案
+
+### Transport trait 新增 `load_graph` 方法
+
+```rust
+trait ProcessingTransport {
+    // 现有方法...
+
+    /// 解析项目文件 JSON，填充默认参数值，返回 SerializedGraph。
+    fn load_graph(&self, json: &str) -> Result<SerializedGraph, String>;
+}
+```
+
+`LocalTransport` 用内部 `NodeRegistry` 实现。将来 `HttpTransport` 通过 HTTP 请求远端实现。
+
+这是唯一需要 registry 内部数据参与的"重"操作（填充默认值需要遍历所有节点的 ParamDef）。
+
+### Serializer 改用 `NodeTypeDef`
+
+`snapshot()` 和 `restore()` 的参数从 `&NodeRegistry` 改为 `&HashMap<String, NodeTypeDef>`。
+
+`NodeTypeDef` 已经包含 pin 定义（名称、顺序）和参数默认值，足以完成：
+- pin 索引 ↔ 名称转换
+- 节点实例化（从 ParamDefInfo 构建默认参数）
+
+节点实例化逻辑（参数默认值只会是标量类型，`ParamValue::to_value()` 不会丢失信息）：
+```rust
+fn instantiate_from_def(def: &NodeTypeDef) -> NodeInstance {
+    NodeInstance {
+        type_id: def.type_id.clone(),
+        params: def.params.iter()
+            .map(|p| (p.name.clone(), p.default.to_value()))
+            .collect(),
+    }
+}
+```
+
+`load()` 从 Serializer 中移除，改为 `transport.load_graph()`。
+`save()` 保持不变（纯 serde 序列化，不需要 registry）。
+
+### 未知节点的 fallback
+
+当前 `restore()` 在 `registry.instantiate()` 返回 None 时会创建 placeholder NodeInstance，保留图结构完整性。改用 `NodeTypeDef` 后保留相同行为：type_defs 中查不到的类型，直接用保存的参数创建 placeholder（不填默认值）。
+
+### App 缓存节点类型定义
+
+`NodeViewer` 中已有 `node_type_defs: Vec<NodeTypeDef>` 字段（启动时通过 `transport.node_types()` 填充）。将其改为 `HashMap<String, NodeTypeDef>` 并复用，不新增第二个缓存。
+
+## 改动范围
+
+| 文件 | 改动 |
+|------|------|
+| `crates/nodeimg-engine/src/transport/mod.rs` | `ProcessingTransport` trait 新增 `load_graph` 方法 |
+| `crates/nodeimg-engine/src/transport/local.rs` | `LocalTransport` 实现 `load_graph`（搬 Serializer::load 的默认值填充逻辑） |
+| `crates/nodeimg-app/src/node/serial.rs` | 移除 `load()`；`snapshot`/`restore` 参数从 `&NodeRegistry` 改为 `&HashMap<String, NodeTypeDef>`；移除 `use nodeimg_engine::NodeRegistry` |
+| `crates/nodeimg-app/src/app.rs` | 移除所有 `with_registry()` 调用；加载用 `transport.load_graph()`；snapshot/restore 用缓存的 type_defs；新增 `node_type_defs: HashMap<String, NodeTypeDef>` 字段 |
+
+## 不做什么
+
+- 不新增数据类型（复用现有 `SerializedGraph`、`NodeTypeDef`）
+- 不新增 `save_graph` 方法（save 是纯 JSON 序列化，不需要 registry）
+- 不移除 `with_registry()`（engine 内部仍需要，只是 app 不再使用）
+- 不动 `SerializedGraph` 等类型（已在 `nodeimg-types` 中）
+- 不改 `NodeViewer` 中对 `LocalTransport` 具体方法的其他调用（如 `instantiate()`、`generate_menu()`、`register_remote_nodes()`），这些是后续 issue 的范围


### PR DESCRIPTION
## Summary

- Transport trait 新增 `load_graph` 方法，将 JSON 解析 + 默认参数填充逻辑封装在 Transport 层
- Serializer 改用 `NodeTypeDef`（通过 `node_types()` 获取）代替 `NodeRegistry`
- App 移除所有 `with_registry()` 调用，不再依赖 `NodeRegistry`

## 动机

- `with_registry()` 是 `LocalTransport` 的具体方法，远程 Transport 无法实现
- App 不应直接接触 engine 内部类型 `NodeRegistry`
- 无头运行（nodeimg-server）需要复用序列化逻辑

## 改动

1. `transport/mod.rs` — `ProcessingTransport` trait 新增 `load_graph` 方法
2. `transport/local.rs` — `LocalTransport` 实现 `load_graph`（+ 3 个测试）
3. `viewer.rs` — `node_type_defs` 从 `Vec` 改为 `HashMap` 以支持高效查找
4. `serial.rs` — `snapshot/restore` 参数从 `&NodeRegistry` 改为 `&HashMap<String, NodeTypeDef>`；移除 `load()` 方法
5. `app.rs` — 移除全部 7 处 `with_registry()` 调用

Closes #73

## Test plan

- [x] `cargo test --workspace` — 109 个测试全部通过
- [x] `cargo build -p nodeimg-app --release` — 编译成功
- [x] `grep -r "NodeRegistry\|with_registry" crates/nodeimg-app/` — 零匹配

🤖 Generated with [Claude Code](https://claude.com/claude-code)